### PR TITLE
Binder with NSFormatter

### DIFF
--- a/THObserversAndBinders/THBinder.h
+++ b/THObserversAndBinders/THBinder.h
@@ -21,6 +21,10 @@ typedef id(^THBinderTransformationBlock)(id value);
 
 + (id)binderFromObject:(id)fromObject keyPath:(NSString *)fromKeyPath
               toObject:(id)toObject keyPath:(NSString *)toKeyPath
+			 formatter:(NSFormatter *)formatter;
+
++ (id)binderFromObject:(id)fromObject keyPath:(NSString *)fromKeyPath
+              toObject:(id)toObject keyPath:(NSString *)toKeyPath
    transformationBlock:(THBinderTransformationBlock)transformationBlock;
 
 // This is a one-way street. Call it to stop the observer functioning.

--- a/THObserversAndBinders/THBinder.m
+++ b/THObserversAndBinders/THBinder.m
@@ -76,6 +76,13 @@
                               transformationBlock:transformationBlock];
 }
 
-
++ (id)binderFromObject:(id)fromObject keyPath:(NSString *)fromKeyPath toObject:(id)toObject keyPath:(NSString *)toKeyPath formatter:(NSFormatter *)formatter;
+{
+	return [[self alloc] initForBindingFromObject:fromObject keyPath:fromKeyPath
+                                         toObject:toObject keyPath:toKeyPath
+                              transformationBlock:^id(id value) {
+                                  return [formatter stringForObjectValue: value];
+                              }];
+}
 
 @end

--- a/THObserversAndBindersTests/THObserversAndBindersTests.m
+++ b/THObserversAndBindersTests/THObserversAndBindersTests.m
@@ -452,4 +452,24 @@
     [binder stopBinding];
 }
 
+- (void)testBindingWithFormatter
+{
+    NSMutableDictionary *testFrom = [NSMutableDictionary dictionaryWithObject:@1 forKey:@"testFromKey"];
+    NSMutableDictionary *testTo = [NSMutableDictionary dictionaryWithObject:@0 forKey:@"testToKey"];
+
+	NSNumberFormatter *formatter = [NSNumberFormatter new];
+	formatter.numberStyle = NSNumberFormatterNoStyle;
+
+    THBinder *binder = [THBinder binderFromObject:testFrom keyPath:@"testFromKey"
+                                         toObject:testTo keyPath:@"testToKey"
+										formatter:formatter];
+
+    testFrom[@"testFromKey"] = @5;
+
+    STAssertEqualObjects(testTo[@"testToKey"], @"5", @"Transformed value in to object is not correct");
+
+    [binder stopBinding];
+}
+
+
 @end


### PR DESCRIPTION
Add binderFromObject:keyPath:toObject:keyPath:formatter: method to create a binder that uses a NSFormatter (like NSDateFormatter or NSNumberFormatter)
